### PR TITLE
Do not allow empty password and empty username (#9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 cache: pip
 language: python
 python:
-    - 2.7
-    - 3.6
+  - 2.7
+  - 3.6
 os: linux
 sudo: required
 dist: trusty
 
-# command to install dependencies
 install:
-  - ./.travis/install.sh
+  - chmod +x .travis/install.sh
+  - .travis/install.sh
 before_script:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
-# command to run tests
 script:
-- ./.travis/run.sh
+  - chmod +x .travis/run.sh
+  - .travis/run.sh
+
+deploy:
+  provider: pypi
+  user: uilianries
+  password:
+    secure: yGrLzRVZTkV9Sax7fEgJjxFBnkocZGwE5wtHy4hzaByI7SeUO3nKvDGiYESw0OnV0ri7LIZ8CauvH9ltyAkLiLZH3saV0z5c5l2f34R5vy3PoEgk1FG6Wv/HBVnYHY3d1IfzjwK9LZintIMkFkt7WYWgOR+FtaFUip81pAW8EbNe36RHms44dL74oZbvHH5fUBXIxwOxP5L+6+H3tob4YQKlP59GgxeGhv8QfpHHMEHDiwbBDeooV1aD4o1VXc2Aw/6n1rnGRELUaxz+5XwnhW5Uw+bMS6sG7GwQb00R/AOCWa4tT+fo643Hh8xtWb1dfNh+0Qcy4gkzZ7Ebwinz+skEmiS7zMWBhnuNJaJicKvUMHgOoB3Q0sqsFaEXYVVGXVh5ZTFYfQKNdASXg8G/A0cLRyFB1JKGi3McBTMs7cjvLhA3E1XZifP1S/Lx3u4tJojS8ZWgDpy9g5DvD4cefO8UZkyzO2r0Prh10EA+Z7EFn+M/hHdwahd++OzEV/L0/SAOUze1ki/SKHYdICUd3P/lqzCKF4eOadEwuqA9Rgj5Yk9A8w1adImhxc20rfIOPUk5vqReXagxg1z4pDcHa7rsmkN/XceIed/pU16H4X9IkQoXFiLjo7svm5Bak5MZl9M7KefiOLusGVOOqmIb7GhVKR4DSQPqA/SDMwWIcJY=

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -11,5 +11,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 fi
 
 conan user
+# Validate distribution
+python setup.py sdist
+# Execute unit tests
 mkdir -p ~/.conan_server/plugins/authenticator/
-nosetests conan.test
+nosetests -v --with-coverage --cover-package=conan .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/uilianries/conan-ldap-authentication.svg?branch=master)](https://travis-ci.org/uilianries/conan-ldap-authentication) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/uilianries/conan-ldap-authentication.svg?branch=master)](https://travis-ci.org/uilianries/conan-ldap-authentication)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Pypi Download](https://img.shields.io/badge/download-pypi-blue.svg)](https://pypi.python.org/pypi/conan-ldap-authentication)
 # Conan LDAP Authentication
 
 A LDAP authentication plugin for [Conan.io](https://conan.io)
@@ -69,6 +71,12 @@ Just call conan authentication, as before
     $ conan user -p my_ldap_password my_ldap_username
 
 Conan will use your username and password to authenticate to registered LDAP server.
+
+## Tests and Development
+
+To run all unit tests:
+
+    $ nosetests -v --with-coverage --cover-package=conan .
 
 ## Dependencies
 

--- a/conan/ldap_authentication.py
+++ b/conan/ldap_authentication.py
@@ -125,6 +125,10 @@ class LDAPAuthenticator(object):
     def valid_user(self, username, password):
         result = False
         try:
+            if not username:
+                raise Exception('Empty username provided.')
+            if not password:
+                raise Exception('Empty password provided.')
             config_file = LDAPConfigFile().path()
             conf = LDAPConfiguration(config_file)
             connection = ldap.initialize(conf.host)

--- a/conan/requirements_test.txt
+++ b/conan/requirements_test.txt
@@ -1,2 +1,3 @@
 nose>=1.3.7
 conan>=0.22.2
+coverage>=4.4.2

--- a/conan/test/test_authentication.py
+++ b/conan/test/test_authentication.py
@@ -56,6 +56,14 @@ distinguished_name: cn=$username,dc=example,dc=com
         authenticator = ldap_authentication.get_class()
         self.assertFalse(authenticator.valid_user(username="read-only-admin", password="foobar"))
 
+    def test_empty_password(self):
+        authenticator = ldap_authentication.get_class()
+        self.assertFalse(authenticator.valid_user(username="read-only-admin", password=None))
+
+    def test_empty_username(self):
+        authenticator = ldap_authentication.get_class()
+        self.assertFalse(authenticator.valid_user(username=None, password="password"))
+
     def __create_config_file(self, file_content):
         self.__temp_file = NamedTemporaryFile(prefix="ldap-authentication-", delete=False)
         with open(self.__temp_file.name, 'w') as file:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.1.3",
+    version="0.2.0",
 
     description='LDAP authenticator for Conan C/C++ package manager',
 


### PR DESCRIPTION
- Both username and password must be filled to be accepted
- Added unit tests to valid new behavior
- Added auto deploy on pypi
- Added code coverage support

Closes #9